### PR TITLE
Merge xrdfs ls

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -16,7 +16,7 @@ in parallel.
 import os
 import time
 import hashlib
-import pickle
+import cPickle
 import random
 import logging
 import multiprocessing
@@ -313,6 +313,7 @@ class DirectoryInfo(object):
                        in the directory.
     """
 
+    __slots__ = ('directories', 'timestamp', 'name', 'hash', 'files', 'mtime', 'can_compare')
     def __init__(self, name='', directories=None, files=None):
         self.directories = directories or []
         self.timestamp = time.time()
@@ -444,7 +445,7 @@ class DirectoryInfo(object):
         """
 
         with open(file_name, 'w') as outfile:
-            pickle.dump(self, outfile)
+            cPickle.dump(self, outfile, protocol=cPickle.HIGHEST_PROTOCOL)
 
     def display(self, path=''):
         """
@@ -765,7 +766,7 @@ def get_info(file_name):
     """
 
     infile = open(file_name, 'r')
-    output = pickle.load(infile)
+    output = cPickle.load(infile)
     infile.close()
 
     return output

--- a/datatypes.py
+++ b/datatypes.py
@@ -160,8 +160,12 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
                     thread_log.debug('Creating retry list, excluding %s', track_failed)
 
                     # Threads to retry cannot be the ones in the failed list so far
-                    retry_candidates = [queue for queue in range(n_threads) \
-                                            if queue not in track_failed]
+#                    retry_candidates = [queue for queue in range(n_threads) \
+#                                            if queue not in track_failed]
+###
+                    retry_candidates = []
+###
+
                     thread_log.debug('Retry candidates created: %s', retry_candidates)
 
                     # If there are threads where we can retry this, put the input there

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -234,12 +234,15 @@ class XRootDLister(object):
 
             self.log.warning('While listing %s: %s', path, status.message)
 
-            error_code = self.error_re.search(status.message).group(1)
+            try:
+                error_code = self.error_re.search(status.message).group(1)
 
-            # Retry certain error codes if there's no dir_list
-            # Don't bother with 3010 at the moment because there's that Hadoop bug
-            okay = (error_code == '3010' and 'operation not permitted' in status.message) or \
-                (bool(dir_list) and error_code in ['!', '3005'])
+                # Retry certain error codes if there's no dir_list
+                # Don't bother with 3010 at the moment because there's that Hadoop bug
+                okay = (error_code == '3010' and 'operation not permitted' in status.message) or \
+                    (bool(dir_list) and error_code in ['!', '3005'])
+            except AttributeError:  # No good match
+                okay = False
 
             self.log.debug('Error code: %s', error_code)
             self.log.debug('Directory List: %s', dir_list)

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -210,7 +210,7 @@ class XRootDLister(object):
         self.log.debug('Using door at %s to list directory %s', door.url, path)
 
         if self.site in self.access and self.access[self.site] == 'directx':
-            return self.direct_list(door,path)
+            return self.direct_list(door, path)
 
         # http://xrootd.org/doc/python/xrootd-python-0.1.0/modules/client/filesystem.html#XRootD.client.FileSystem.dirlist
         status, dir_list = door.dirlist(path, flags=XRootD.client.flags.DirListFlags.STAT)
@@ -256,7 +256,8 @@ class XRootDLister(object):
 
         return okay, directories, files
 
-    def direct_list(self, door, path):
+    @staticmethod
+    def direct_list(door, path):
         """
         Do the listing using system calls
 
@@ -269,7 +270,7 @@ class XRootDLister(object):
 
         directories = []
         files = []
-        
+
         doorname = str(door.url.hostname) + ':' + str(door.url.port)
         cmd = 'xrdfs ' + doorname + ' ls -l ' + path
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -283,14 +284,14 @@ class XRootDLister(object):
             fields = line.strip().split()
             if len(fields) < 1:
                 continue
-            itemName = fields[-1]
-            itemSize = int(fields[3])
+            item_name = fields[-1]
+            item_size = int(fields[3])
             tstamp = int(time.mktime(time.strptime(fields[1], '%Y-%m-%d')))
 
             if fields[0].startswith('d'):
-                directories.append((itemName, tstamp))
+                directories.append((item_name, tstamp))
             else:
-                files.append((itemName, itemSize, tstamp))
+                files.append((item_name, item_size, tstamp))
 
         return True, directories, files
 

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -172,6 +172,7 @@ class XRootDLister(object):
         self.do_both = do_both
 
         self.store_prefix = config_dict.get('PathPrefix', {}).get(site, '')
+        self.access = config_dict.get('AccessMethod', {})
         self.tries = config_dict.get('Retries', 0) + 1
         self.ignore_list = config_dict.get('IgnoreDirectories', [])
         self.site = site
@@ -284,7 +285,7 @@ class XRootDLister(object):
             fields = line.strip().split()
             if len(fields) < 1:
                 continue
-            item_name = fields[-1]
+            item_name = os.path.basename(fields[-1].rstrip('/'))
             item_size = int(fields[3])
             tstamp = int(time.mktime(time.strptime(fields[1], '%Y-%m-%d')))
 

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -53,9 +53,6 @@ class GFallDLister(object):
         return epoch
 
     def ls_directory(self, path):
-
-#        print 'Using SRM to list directory ' + path
-
         directories = []
         files = []
 
@@ -358,7 +355,7 @@ def get_site_tree(site):
         # Return the DirectoryInfo 
         print '------------------------'
         print time.time()
-        return datatypes.DirectoryInfo(name='/store', to_merge=directories)
+        return datatypes.DirectoryInfo(name='/store', directories=directories)
 
 
     # Get the redirector for a site
@@ -404,4 +401,4 @@ def get_site_tree(site):
         ]
 
     # Return the DirectoryInfo
-    return datatypes.DirectoryInfo(name='/store', to_merge=directories)
+    return datatypes.DirectoryInfo(name='/store', directories=directories)

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-complex
-
 """
 Tool to get the files located at a site.
 
@@ -7,8 +5,7 @@ Tool to get the files located at a site.
 
    Must be used on a machine with XRootD python module installed.
 
-:author: Daniel Abercrombie <dabercro@mit.edu> \n
-         Max Goncharov <maxi@mit.edu>
+:author: Daniel Abercrombie <dabercro@mit.edu>
 """
 
 import os
@@ -17,54 +14,26 @@ import logging
 import random
 import itertools
 import time
-import subprocess
 from datetime import datetime
-
-import timeout_decorator
+import subprocess,signal
 
 import XRootD.client
-from common.interface.mysql import MySQL
+import timeout_decorator
 
 from . import config
 from . import datatypes
 from . import cache_tree
 
+from common.interface.mysql import MySQL
 
 LOG = logging.getLogger(__name__)
 
-def ct_timestamp(line):
-    """
-    Takes a time string from gfal and extracts the time since epoch
-
-    .. todo::
-      Make this more elegant and inline in the :py:func:`GFallDLister.ls_directory`
-
-    :param str line: The line from the gfal-ls call including month, day, and year
-                     in some format with lots of hypens
-    :returns: Timestamp's time since epoch
-    :rtype: int
-    """
-
-    fields = line.split('-')
-    if ':' in fields[-1]:
-        fields[-1] = datetime.now().year
-    month = time.strptime(fields[0], '%b').tm_mon
-    datestr = str(month) + '-' + str(fields[1]) + '-' + str(fields[2])
-
-    epoch = int(time.mktime(time.strptime(datestr, '%m-%d-%Y')))
-    return epoch
-
 class GFallDLister(object):
-    """
-    An object to list a site through ``gfal-ls`` calls
-    """
-
-    def __init__(self, site):
+    def __init__(self,site):
         config_dict = config.config_dict()
 
         self.store_prefix = config_dict.get('PathPrefix', {}).get(site, '')
         self.tries = config_dict.get('Retries', 0) + 1
-        self.ignore_list = config_dict.get('IgnoreDirectories', [])
         self.site = site
 
         self.log = logging.getLogger(__name__)
@@ -73,14 +42,19 @@ class GFallDLister(object):
         sqlline = "select backend from sites where name='" + site + "'"
         self.backend = (self.mysql_reg.query(sqlline))[0]
 
-    def ls_directory(self, path):
-        """
-        Gets the contents of a path
+    def ct_timestamp(self, line):
+        fields = line.split('-')
+        if ':' in fields[-1]:
+            fields[-1] = datetime.now().year
+        month = time.strptime(fields[0],'%b').tm_mon
+        datestr = str(month) + '-' + str(fields[1]) + '-' + str(fields[2])
 
-        :param str path: The full path, starting with ``/store/``, of the directory to list.
-        :returns: A bool indicating the success, a list of directories, and a list of files.
-        :rtype: bool, list, list
-        """
+        epoch = int(time.mktime(time.strptime(datestr, '%m-%d-%Y')))
+        return epoch
+
+    def ls_directory(self, path):
+
+#        print 'Using SRM to list directory ' + path
 
         directories = []
         files = []
@@ -89,51 +63,35 @@ class GFallDLister(object):
 
         cmd = 'gfal-ls -l ' + full_path
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                   bufsize=4096, shell=True)
+                                   bufsize=4096,shell=True)
         strout, error = process.communicate()
         if process.returncode != 0:
             print error
             return False, directories, files
-
+        
         for line in strout.split('\n'):
             fields = line.strip().split()
             if len(fields) < 1:
                 continue
-            item_name = fields[-1]
-            item_size = int(fields[4])
-            tstamp = ct_timestamp(fields[5] + '-' + fields[6] + '-' + fields[7])
+            itemName = fields[-1]
+            itemSize = int(fields[4])
+            tstamp = self.ct_timestamp(fields[5] + '-' + fields[6] + '-' + fields[7])
+            marker = fields[0]
 
             if fields[0].startswith('d'):
-                directories.append((item_name, tstamp))
+                directories.append((itemName,tstamp))
             else:
-                files.append((item_name, item_size, tstamp))
-
+                files.append((itemName,itemSize,tstamp))
+        
         return True, directories, files
 
     def list(self, path, retries=1):
-        """
-        Return the directory contents at the given path.
-        The ``list`` member is expected of every object passed to :py:mod:`datatypes`.
-
-        :param str path: The full path, starting with ``/store/``, of the directory to list.
-        :param int retries: Number of attempts so far
-        :returns: A bool indicating the success, a list of directories, and a list of files.
-                  The list of directories consists of tuples of (directory name, mod time).
-                  The list of files consistents of tuples of (file name, size, mod time).
-                  The modification times are in seconds from epoch and the file size is in bytes.
-        :rtype: bool, list, list
-        """
-
-        # Skip over paths that include part of the list of ignored directories
-        for pattern in self.ignore_list:
-            if pattern in path:
-                return True, [], []
-
+        
         if retries == self.tries:
             self.log.error('Giving up on %s due to too many retries', path)
             return False, [], []
 
-        try:
+        try:            
             okay, directories, files = self.ls_directory(path)
              # We could add sleep, reconnecting and other error handling here, if desired
             if not okay:
@@ -141,7 +99,7 @@ class GFallDLister(object):
 
         except timeout_decorator.TimeoutError:
             self.log.warning('Directory %s timed out.', path)
-            okay, directories, files = self.list(path, retries + 1)
+            okay, directories, files =  self.list(path, retries + 1)
 
         return okay, directories, files
 
@@ -153,18 +111,22 @@ class XRootDLister(object):
     then a fallback connection is used.
     This keeps the load of listing from hitting more than half
     of a site's doors at a time.
-
-    :param str primary_door: The URL of the door that will get the most load
-    :param str backup_door: The URL of the door that will be used when
-                            the primary door fails
-    :param str site: The site that this connection is to.
-    :param int thread_num: This optional parameter is only used to
-                           Create a separate logger for this object
-    :param bool do_both: If true, the primary and backup doors will both
-                         be used for every listing
     """
 
     def __init__(self, primary_door, backup_door, site, thread_num=None, do_both=False):
+        """
+        Set up the class with two doors.
+
+        :param str primary_door: The URL of the door that will get the most load
+        :param str backup_door: The URL of the door that will be used when
+                                the primary door fails
+        :param str site: The site that this connection is to.
+        :param int thread_num: This optional parameter is only used to
+                               Create a separate logger for this object
+        :param bool do_both: If true, the primary and backup doors will both
+                             be used for every listing
+        """
+
         config_dict = config.config_dict()
 
         self.primary_conn = XRootD.client.FileSystem(primary_door)
@@ -172,8 +134,8 @@ class XRootDLister(object):
         self.do_both = do_both
 
         self.store_prefix = config_dict.get('PathPrefix', {}).get(site, '')
+        self.access =  config_dict.get('AccessMethod', {})
         self.tries = config_dict.get('Retries', 0) + 1
-        self.ignore_list = config_dict.get('IgnoreDirectories', [])
         self.site = site
 
         # This regex is used to parse the error code and propose a retry
@@ -208,6 +170,9 @@ class XRootDLister(object):
             path += '/'
 
         self.log.debug('Using door at %s to list directory %s', door.url, path)
+
+        if self.site in self.access and self.access[self.site] == 'directx':
+            return self.direct_list(door,path)
 
         # http://xrootd.org/doc/python/xrootd-python-0.1.0/modules/client/filesystem.html#XRootD.client.FileSystem.dirlist
         status, dir_list = door.dirlist(path, flags=XRootD.client.flags.DirListFlags.STAT)
@@ -250,6 +215,34 @@ class XRootDLister(object):
 
         return okay, directories, files
 
+    def direct_list(self,door,path):
+        directories = []
+        files = []
+        
+        doorname = str(door.url.hostname) + ':' + str(door.url.port)
+        cmd = 'xrdfs ' + doorname + ' ls -l ' + path
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                   bufsize=4096,shell=True)
+        strout, error = process.communicate()
+        if process.returncode != 0:
+            print error
+            return False, directories, files
+
+        for line in strout.split('\n'):
+            fields = line.strip().split()
+            if len(fields) < 1:
+                continue
+            itemName = fields[-1]
+            itemSize = int(fields[3])
+            tstamp = int(time.mktime(time.strptime(fields[1], '%Y-%m-%d')))
+
+            if fields[0].startswith('d'):
+                directories.append((itemName,tstamp))
+            else:
+                files.append((itemName,itemSize,tstamp))
+
+        return True, directories, files
+
     def list(self, path, retries=0):
         """
         Return the directory contents at the given path.
@@ -264,10 +257,8 @@ class XRootDLister(object):
         :rtype: bool, list, list
         """
 
-        # Skip over paths that include part of the list of ignored directories
-        for pattern in self.ignore_list:
-            if pattern in path:
-                return True, [], []
+        if 'HCTest' in path:
+            return True, [], []
 
         if retries == self.tries:
             self.log.error('Giving up on %s due to too many retries', path)
@@ -347,43 +338,46 @@ def get_site_tree(site):
 
     :param str site: The site name
     :returns: The site directory listing information
-    :rtype: dynamo_consistency.datatypes.DirectoryInfo
+    :rtype: ConsistencyCheck.datatypes.DirectoryInfo
     """
+    print '------------------------'
+    print time.time()
 
-    config_dict = config.config_dict()
-    access = config_dict.get('AccessMethod', {})
-    if access.get(site) == 'SRM':
-        num_threads = int(config_dict.get('GFALThreads'))
-        LOG.info('threads = %i', num_threads)
+    min_threads = config.config_dict().get('MinThreads', 0)
+    max_threads = config.config_dict().get('MaxThreads')
+
+    access =  config.config_dict().get('AccessMethod', site)
+    if site in access and access[site] == 'SRM':
         directories = [
-            datatypes.create_dirinfo('/store', directory, GFallDLister, [[site]]*num_threads) \
+            datatypes.create_dirinfo('/store', directory, GFallDLister, [[site]]*max_threads ) \
                 for directory in config.config_dict().get('DirectoryList', [])
         ]
-        # Return the DirectoryInfo
-        return datatypes.DirectoryInfo(name='/store', directories=directories)
+        # Return the DirectoryInfo 
+        print '------------------------'
+        print time.time()
+        return datatypes.DirectoryInfo(name='/store', to_merge=directories)
 
 
     # Get the redirector for a site
     # The redirector can be used for a double check (not implemented yet...)
     # The redir_list is used for the original listing
-    num_threads = int(config_dict.get('NumThreads'))
 
     balancer, door_list = config.get_redirector(site)
     LOG.debug('Full redirector list: %s', door_list)
 
     # Bool to determine if using both doors in each connection
-    do_both = bool(site in config_dict.get('BothList', []))
+    do_both = bool(site in config.config_dict().get('BothList', []))
 
-    if site in config_dict.get('UseLoadBalancer', []) or \
+    if site in config.config_dict().get('UseLoadBalancer', []) or \
             (balancer and not door_list):
-        num_threads = 1
+        min_threads = 1
         door_list = [balancer]
 
     if not door_list:
         LOG.error('No doors found. Returning emtpy tree')
         return datatypes.DirectoryInfo(name='/store')
 
-    while num_threads > (len(door_list) + 1)/2:
+    while min_threads > (len(door_list) + 1)/2:
         if do_both or len(door_list) % 2:
             door_list.extend(door_list)
         else:
@@ -393,8 +387,6 @@ def get_site_tree(site):
 
     # Add the first door to the end, in case we have an odd number of doors
     door_list.append(door_list[0])
-    # Strip off the extra threads
-    door_list = door_list[:num_threads * 2]
 
     # Create DirectoryInfo for each directory to search (set in configuration file)
     # The search is done with XRootDLister objects that have two doors and the thread
@@ -405,8 +397,8 @@ def get_site_tree(site):
             '/store/', directory, XRootDLister,
             [(prim, back, site, thread_num, do_both) for prim, back, thread_num in \
                  zip(door_list[0::2], door_list[1::2], range(len(door_list[1::2])))]) \
-            for directory in config_dict.get('DirectoryList', [])
+            for directory in config.config_dict().get('DirectoryList', [])
         ]
 
     # Return the DirectoryInfo
-    return datatypes.DirectoryInfo(name='/store', directories=directories)
+    return datatypes.DirectoryInfo(name='/store', to_merge=directories)

--- a/prod/check_sam.py
+++ b/prod/check_sam.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+
+import sys
+import sqlite3
+
+from CMSToolBox.samstatus import is_sam_good
+
+if __name__ == '__main__':
+    database = sys.argv[1]
+    sites = sys.argv[2:]
+
+    conn = sqlite3.connect(database)
+    curs = conn.cursor()
+
+    for site in sites:
+        if 'T2' in site:
+            try:
+                if not is_sam_good(site):
+                    curs.execute('UPDATE sites SET isrunning = -1 WHERE site = ? AND isrunning = 0', (site, ))
+            except:
+                print '%s not in SAM tests!' % site
+
+    conn.commit()
+    conn.close()

--- a/prod/check_sam.py
+++ b/prod/check_sam.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# pylint: disable=too-complex
+# pylint: disable=bare-except
 
 """
 A script that updates the summary database to not run on sites failing SAM tests lately

--- a/prod/check_sam.py
+++ b/prod/check_sam.py
@@ -1,13 +1,24 @@
 #! /usr/bin/env python
+# pylint: disable=too-complex
+
+"""
+A script that updates the summary database to not run on sites failing SAM tests lately
+
+:author: Daniel Abercrombie <dabercro@mit.edu>
+"""
 
 import sys
 import sqlite3
 
 from CMSToolBox.samstatus import is_sam_good
 
-if __name__ == '__main__':
-    database = sys.argv[1]
-    sites = sys.argv[2:]
+def main(database, sites):
+    """
+    Updates the database to not run on sites with bad SAM tests
+
+    :param str database: Location of the database file
+    :param list sites: List of all of the sites to check
+    """
 
     conn = sqlite3.connect(database)
     curs = conn.cursor()
@@ -16,9 +27,15 @@ if __name__ == '__main__':
         if 'T2' in site:
             try:
                 if not is_sam_good(site):
-                    curs.execute('UPDATE sites SET isrunning = -1 WHERE site = ? AND isrunning = 0', (site, ))
+                    curs.execute(
+                        'UPDATE sites SET isrunning = -1 WHERE site = ? AND isrunning = 0',
+                        (site, )
+                        )
             except:
                 print '%s not in SAM tests!' % site
 
     conn.commit()
     conn.close()
+
+if __name__ == '__main__':
+    main(database=sys.argv[1], sites=sys.argv[2:])

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -468,22 +468,23 @@ def main(site):
         conn.close()
 
     # Make a JSON file reporting storage usage
-    storage = {
-        'storeageservice': {
-            'storageshares': [{
-                'numberoffiles': node.get_num_files(),
-                'path': [os.path.normpath('/store/%s' % subdir)],
-                'timestamp': str(int(time.time())),
-                'totalsize': 0,
-                'usedsize': node.get_directory_size()
-                } for node, subdir in [(site_tree.get_node(path), path) for path in
-                                       [''] + config_dict['DirectoryList']]
-                              if node.get_num_files()]
+    if site_tree.get_num_files():
+        storage = {
+            'storeageservice': {
+                'storageshares': [{
+                        'numberoffiles': node.get_num_files(),
+                        'path': [os.path.normpath('/store/%s' % subdir)],
+                        'timestamp': str(int(time.time())),
+                        'totalsize': 0,
+                        'usedsize': node.get_directory_size()
+                        } for node, subdir in [(site_tree.get_node(path), path) for path in
+                                               [''] + config_dict['DirectoryList']]
+                                  if node.get_num_files()]
+                }
             }
-        }
 
-    with open(os.path.join(webdir, '%s_storage.json' % site), 'w') as storage_file:
-        json.dump(storage, storage_file)
+        with open(os.path.join(webdir, '%s_storage.json' % site), 'w') as storage_file:
+            json.dump(storage, storage_file)
 
 if __name__ == '__main__':
 

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -472,13 +472,13 @@ def main(site):
         storage = {
             'storeageservice': {
                 'storageshares': [{
-                        'numberoffiles': node.get_num_files(),
-                        'path': [os.path.normpath('/store/%s' % subdir)],
-                        'timestamp': str(int(time.time())),
-                        'totalsize': 0,
-                        'usedsize': node.get_directory_size()
-                        } for node, subdir in [(site_tree.get_node(path), path) for path in
-                                               [''] + config_dict['DirectoryList']]
+                    'numberoffiles': node.get_num_files(),
+                    'path': [os.path.normpath('/store/%s' % subdir)],
+                    'timestamp': str(int(time.time())),
+                    'totalsize': 0,
+                    'usedsize': node.get_directory_size()
+                    } for node, subdir in [(site_tree.get_node(path), path) for path in
+                                           [''] + config_dict['DirectoryList']]
                                   if node.get_num_files()]
                 }
             }

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -395,8 +395,7 @@ def main(site):
                    INNER JOIN block_replicas ON block_replicas.block_id = files.block_id
                    INNER JOIN sites ON block_replicas.site_id = sites.id
                    LEFT JOIN groups ON block_replicas.group_id = groups.id
-                   WHERE files.name = %s AND sites.name = %s
-                   """
+                   WHERE files.name = %s AND sites.name = %s """
 
     with open('%s_compare_missing.txt' % site, 'r') as input_file:
         for line in input_file:

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -59,7 +59,8 @@
     "T1_UK_RAL_Disk": "SRM",
     "T2_ES_IFCA" : "SRM",
     "T2_FR_GRIF_LLR": "SRM",
-    "T2_PL_Warsaw": "SRM"
+    "T2_PL_Warsaw": "SRM",
+    "T1_US_FNAL_Disk": "directx"
   }, 
   "GlobalRedirectors": [
     "xrootd-redic.pi.infn.it",

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -60,7 +60,8 @@
     "T2_ES_IFCA" : "SRM",
     "T2_FR_GRIF_LLR": "SRM",
     "T2_UK_SGrid_RALPP": "SRM",
-    "T1_US_FNAL_Disk": "directx"
+    "T1_US_FNAL_Disk": "directx",
+    "T2_US_MIT": "directx"
   }, 
   "GlobalRedirectors": [
     "xrootd-redic.pi.infn.it",

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -17,6 +17,7 @@
     "T2_FR_IPHC": "sbgse1.in2p3.fr",
     "T2_CH_CERN": "eoscms.cern.ch:1094",
     "T3_CH_PSI": "t3se01.psi.ch",
+    "T2_FR_CCIN2P3": "ccxrpli003.in2p3.fr:1094",
     "T2_FR_GRIF_LLR": "llrpp01.in2p3.fr:11001",
     "T2_FR_GRIF_IRFU": "node12.datagrid.cea.fr:11001",
     "T2_KR_KNU":  "cluster142.knu.ac.kr:1094",
@@ -52,14 +53,13 @@
     "/TA_Tleptonic_kappa_aut_LO_madspin-pythia8"
   ],
   "BothList": [
-    "T2_FR_CCIN2P3",
-    "T1_US_FNAL"
+    "T1_US_FNALLLL"
   ],
   "AccessMethod": {
     "T1_UK_RAL_Disk": "SRM",
     "T2_ES_IFCA" : "SRM",
     "T2_FR_GRIF_LLR": "SRM",
-    "T2_PL_Warsaw": "SRM"
+    "T2_UK_SGrid_RALPP": "SRM"
   }, 
   "GlobalRedirectors": [
     "xrootd-redic.pi.infn.it",

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -7,8 +7,8 @@
   "ListAge": 0,
   "IgnoreAge": 14,
   "RedirectorAge": 0,
-  "CacheLocation": "/scratch5/dabercro/consistency/cache",
-  "LogLocation": "/scratch5/dabercro/consistency/logs",
+  "CacheLocation": "/local/dynamo/consistency/cache",
+  "LogLocation": "/local/dynamo/consistency/logs",
   "Redirectors": {
     "T1_RU_JINR_Disk": "se-xrd01.jinr-t1.ru:1095",
     "T1_FR_CCIN2P3_Disk": "ccxrpli003.in2p3.fr:1095", 
@@ -60,8 +60,7 @@
     "T2_ES_IFCA" : "SRM",
     "T2_FR_GRIF_LLR": "SRM",
     "T2_UK_SGrid_RALPP": "SRM",
-    "T1_US_FNAL_Disk": "directx",
-    "T2_US_MIT": "directx"
+    "T1_US_FNAL_Disk": "directx"
   }, 
   "GlobalRedirectors": [
     "xrootd-redic.pi.infn.it",
@@ -71,7 +70,7 @@
   "UseLoadBalancer": [
     "T2_US_Vanderbilt"
   ],
-  "WebDir": "/home/dabercro/public_html/ConsistencyCheck",
+  "WebDir": "/home/dynamo/consistency/web",
   "MaxMissing": 1000,
   "MaxOrphan": 10000
 }

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -14,6 +14,7 @@
     "T2_UK_London_Brunel": "dc2-grid-64.brunel.ac.uk",
     "T2_UK_London_IC":     "gfe02.grid.hep.ph.ic.ac.uk:1098",
     "T2_FR_IPHC": "sbgse1.in2p3.fr",
+    "T2_CH_CERN": "eoscms.cern.ch:1094",
     "T3_CH_PSI": "t3se01.psi.ch",
     "T2_FR_GRIF_LLR": "llrpp01.in2p3.fr:11001",
     "T2_FR_GRIF_IRFU": "node12.datagrid.cea.fr:11001",
@@ -22,7 +23,7 @@
     "T2_IT_Rome": "cmsrm-xrootd02.roma1.infn.it:7070",
     "T2_PK_NCP" : "pcncp22.ncp.edu.pk:11001",
     "T2_RU_INR":  "grse001.inr.troitsk.ru:11000",
-    "T2_RU_ITEP": "se3.itep.ru:1094",
+    "T2_RU_ITEP": "se3.itep.ru:1095",
     "T3_US_MIT": "t3serv006.mit.edu"
   },
   "PathPrefix": {
@@ -54,8 +55,8 @@
     "T1_US_FNAL"
   ],
   "AccessMethod": {
+    "T2_ES_IFCA" : "SRM",
     "T2_FR_GRIF_LLR": "SRM",
-    "T2_FR_GRIF_IRFU": "SRM",
     "T2_PL_Warsaw": "SRM"
   }, 
   "GlobalRedirectors": [

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -7,8 +7,8 @@
   "ListAge": 0,
   "IgnoreAge": 14,
   "RedirectorAge": 0,
-  "CacheLocation": "/local/dynamo/consistency/cache",
-  "LogLocation": "/local/dynamo/consistency/logs",
+  "CacheLocation": "/scratch5/dabercro/consistency/cache",
+  "LogLocation": "/scratch5/dabercro/consistency/logs",
   "Redirectors": {
     "T1_RU_JINR_Disk": "se-xrd01.jinr-t1.ru:1095",
     "T1_FR_CCIN2P3_Disk": "ccxrpli003.in2p3.fr:1095", 
@@ -70,7 +70,7 @@
   "UseLoadBalancer": [
     "T2_US_Vanderbilt"
   ],
-  "WebDir": "/home/dynamo/consistency/web",
+  "WebDir": "/home/dabercro/public_html/ConsistencyCheck",
   "MaxMissing": 1000,
   "MaxOrphan": 10000
 }

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -2,7 +2,7 @@
   "Timeout": 300,
   "Retries": 3,
   "NumThreads": 2,
-  "GFALThreads": 6,
+  "GFALThreads": 12,
   "InventoryAge": 0,
   "ListAge": 0,
   "IgnoreAge": 14,
@@ -11,6 +11,7 @@
   "LogLocation": "/local/dynamo/consistency/logs",
   "Redirectors": {
     "T1_RU_JINR_Disk": "se-xrd01.jinr-t1.ru:1095",
+    "T1_FR_CCIN2P3_Disk": "ccxrpli003.in2p3.fr:1095", 
     "T2_UK_London_Brunel": "dc2-grid-64.brunel.ac.uk",
     "T2_UK_London_IC":     "gfe02.grid.hep.ph.ic.ac.uk:1098",
     "T2_FR_IPHC": "sbgse1.in2p3.fr",
@@ -55,6 +56,7 @@
     "T1_US_FNAL"
   ],
   "AccessMethod": {
+    "T1_UK_RAL_Disk": "SRM",
     "T2_ES_IFCA" : "SRM",
     "T2_FR_GRIF_LLR": "SRM",
     "T2_PL_Warsaw": "SRM"

--- a/prod/run_checks.sh
+++ b/prod/run_checks.sh
@@ -89,7 +89,7 @@ then
         LOGLOCATION=$(jq -r '.LogLocation' $HERE/consistency_config.json)
         test -d $LOGLOCATION || mkdir -p $LOGLOCATION
 
-        jq '.AccessMethod' consistency_config.json | grep SRM | grep $SITE
+        jq '.AccessMethod' consistency_config.json | grep SRM | grep $SITE >& /dev/null
         ISSRM=$?
 
         # Get SRM key for lock, if needed

--- a/prod/run_checks.sh
+++ b/prod/run_checks.sh
@@ -64,7 +64,7 @@ LIMIT $NUMBER;
 " | sqlite3 $DATABASE)
 
 # Check machine
-if [ `hostname` = 't3serv016.mit.edu' ]
+if [ "$USER" != "dynamo" -o `hostname` = 't3serv016.mit.edu' ]
 then
 
     # Some additional setup


### PR DESCRIPTION
- Use `xrdfs` commands directly instead of python bindings
- Use binary `cPickle` implementation (instead of ASCII `pickle`)
- Use `__slots__` to try to reduce memory footprint for directories