### PR TITLE
Fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 cache: pip
-addons:
-  apt:
-    sources: debian-sid
-    packages: shellcheck
+# This broke with IPv6 update for some reason
+#addons:
+#  apt:
+#    sources: debian-sid
+#    packages: shellcheck
 matrix:
   include:
     - python: 2.6

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -79,6 +79,7 @@ class Lister(object):
         # Skip over paths that include part of the list of ignored directories
         for pattern in self.ignore_list:
             if pattern in path:
+                LOG.warning('Ignoring %s because of ignored pattern %s', path, pattern)
                 return False, [], []
 
         if retries >= self.tries:

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -79,7 +79,7 @@ class Lister(object):
         # Skip over paths that include part of the list of ignored directories
         for pattern in self.ignore_list:
             if pattern in path:
-                return True, [], []
+                return False, [], []
 
         if retries >= self.tries:
             self.log.error('Giving up on %s due to too many retries', path)

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -182,12 +182,17 @@ class EmptyRemover(object):
         empties = ['/store/' + empty for empty in tree.empty_nodes_list() \
                        if not self.check('/store/' + empty)]
 
+        not_empty = []
+
         for path in empties:
             try:
                 tree.remove_node(path[7:])
             except datatypes.NotEmpty as msg:
                 LOG.warning('While removing %s: %s', path, msg)
-                empties.remove(path)
+                not_empty.append(path)
+
+        for path in not_empty:
+            empties.remove(path)
 
         self.removed += deletion(self.site, empties)
 

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -393,8 +393,7 @@ def main(site):
     config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
 
     # Directories too short to be checked shouldn't be deleted yet
-    remover = EmptyRemover(
-        site, lambda path: True in [d in path for d in config_dict['IgnoreDirectories']])
+    remover = EmptyRemover(site)
     site_tree = getsitecontents.get_site_tree(site, remover)
 
     # Do the comparison

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -162,12 +162,14 @@ class EmptyRemover(object):
     This class handles the removal of empty directories from the tree
     by behaving as a callback.
     :param str site: Site name
-    :param function check: The function to check against orphans to not delete
+    :param function check: The function to check against orphans to not delete.
+                           The full path name is passed to the function.
+                           If it returns ``True``, the directory is not deleted.
     """
 
-    def __init__(self, site, check):
+    def __init__(self, site, check=None):
         self.site = site
-        self.check = check
+        self.check = check or (lambda _: False)
         self.removed = 0
 
     def __call__(self, tree):
@@ -177,11 +179,15 @@ class EmptyRemover(object):
         :type tree: :py:class:`datatypes.DirectoryInfo`
         """
         tree.setup_hash()
-        empties = ['/store/' + empty for empty in tree.empty_nodes_list() if \
-                       empty.split('/') > 4 and not self.check('/store/' + empty)]
+        empties = ['/store/' + empty for empty in tree.empty_nodes_list() \
+                       if not self.check('/store/' + empty)]
 
         for path in empties:
-            tree.remove_node(path[7:])
+            try:
+                tree.remove_node(path[7:])
+            except datatypes.NotEmpty as msg:
+                LOG.warning('While removing %s: %s', path, msg)
+                empties.remove(path)
 
         self.removed += deletion(self.site, empties)
 
@@ -386,7 +392,9 @@ def main(site):
     # Reset the DirectoryList for the XRootDLister to run on
     config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
 
-    remover = EmptyRemover(site, check_orphans)
+    # Directories too short to be checked shouldn't be deleted yet
+    remover = EmptyRemover(
+        site, lambda path: True in [d in path for d in config_dict['IgnoreDirectories']])
     site_tree = getsitecontents.get_site_tree(site, remover)
 
     # Do the comparison

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -46,6 +46,7 @@
   "IgnoreDirectories": [
     "/SAM",
     "/HCTest",
+    "/HCtest",
     "/GenericTTbar",
     "/EWKWPlus2Jets_WToLNu_M-50_14TeV-madgraph-pythia8",
     "/VBFToHHTo4B_SM_14TeV-madgraph-pythia8",

--- a/web/output.html
+++ b/web/output.html
@@ -75,7 +75,7 @@
            $background_nosource = ($row['nosource'] > $config['MaxMissing']) ? $bad_background : '';
            $background_orphan = ($row['orphan'] > $config['MaxOrphan']) ? $bad_background : '';
            $background_files = ($row['files'] == 0) ? $bad_background : '';
-           $background_unlisted = ($row['unlisted'] != 0) ? $bad_background : '';
+           $background_unlisted = ($row['unlisted'] > 6) ? $bad_background : '';
 
            $tooltip = '';
 


### PR DESCRIPTION
- Fix a bug that was throwing lots of warnings in the logs. This will also make the deletion as running more aggressive (optimizing memory usage)
- Track ignored directories by saying they're unlisted. This will prevent us from forgetting about them.
