### PR TITLE
Differentiate unlisted

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -556,6 +556,19 @@ class DirectoryInfo(object):
         return sum([di.get_directory_size() for di in self.directories],
                    sum([fi['size'] for fi in self.files]))
 
+    def get_unlisted(self, path=''):
+        """
+        :param str path: Path to prepend to the name, used in recursive calls
+        :returns: List of directories that were unlisted
+        :rtype: list
+        """
+        here = os.path.join(path, self.name)
+        output = [name for d in self.directories for name in d.get_unlisted(here)]
+        if '_unlisted_' in [f['name'] for f in self.files]:
+            output.append(here)
+
+        return output
+
     def get_num_files(self, unlisted=False, place_new=False):
         """ Report the total number of files stored.
 

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -79,7 +79,7 @@ class Lister(object):
         # Skip over paths that include part of the list of ignored directories
         for pattern in self.ignore_list:
             if pattern in path:
-                LOG.warning('Ignoring %s because of ignored pattern %s', path, pattern)
+                self.log.warning('Ignoring %s because of ignored pattern %s', path, pattern)
                 return False, [], []
 
         if retries >= self.tries:

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -571,7 +571,10 @@ def main(site):
         curs.execute('INSERT INTO stats_history SELECT * FROM stats WHERE site=?', (site, ))
         curs.execute(
             """
-            REPLACE INTO stats VALUES
+            REPLACE INTO stats
+            (`site`, `time`, `files`, `nodes`, `emtpy`, `cores`, `missing`, `m_size`,
+             `orphan`, `o_size`, `entered`, `nosource`, `unlisted`, `unmerged`)
+            VALUES
             (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME(DATETIME(), "-{0} hours"), ?, ?, ?)
             """.format(5 - is_dst),
             (site, time.time() - start, site_tree.get_num_files(),

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -327,6 +327,13 @@ def main(site):
 
     inv_tree = getinventorycontents.get_db_listing(site)
 
+    # Reset the DirectoryList for the XRootDLister to run on
+    config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
+
+    # Directories too short to be checked shouldn't be deleted yet
+    remover = EmptyRemover(site)
+    site_tree = getsitecontents.get_site_tree(site, remover)
+
     # Create the function to check orphans and missing
 
     # First, datasets in the deletions queue can be missing
@@ -393,13 +400,6 @@ def main(site):
     check_missing = lambda x: double_check(x, acceptable_missing)
 
     inv_sql.close()
-
-    # Reset the DirectoryList for the XRootDLister to run on
-    config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
-
-    # Directories too short to be checked shouldn't be deleted yet
-    remover = EmptyRemover(site)
-    site_tree = getsitecontents.get_site_tree(site, remover)
 
     # Do the comparison
     missing, m_size, orphan, o_size = datatypes.compare(

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -568,18 +568,27 @@ def main(site):
         conn = sqlite3.connect(os.path.join(webdir, 'stats.db'))
         curs = conn.cursor()
 
+        unlisted = site_tree.get_num_files(unlisted=True)
+
         curs.execute('INSERT INTO stats_history SELECT * FROM stats WHERE site=?', (site, ))
         curs.execute(
             """
-            REPLACE INTO stats VALUES
-            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME(DATETIME(), "-{0} hours"), ?, ?, ?)
+            REPLACE INTO stats
+            (`site`, `time`, `files`, `nodes`, `emtpy`, `cores`, `missing`, `m_size`,
+             `orphan`, `o_size`, `entered`, `nosource`, `unlisted`, `unmerged`, `unlisted_bad`)
+            VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME(DATETIME(), "-{0} hours"), ?, ?, ?, ?)
             """.format(5 - is_dst),
             (site, time.time() - start, site_tree.get_num_files(),
              remover.get_removed_count() + site_tree.count_nodes(),
              remover.get_removed_count() + len(site_tree.empty_nodes_list()),
              config_dict.get('NumThreads', config_dict.get('MinThreads', 0)),
              len(missing), m_size, len(orphan), o_size, len(no_source_files),
-             site_tree.get_num_files(unlisted=True), unmerged))
+             len(unlisted), unmerged,
+             len([d for d in unlisted \
+                      if True not in [i in d for i in config_dict['IgnoreDirectories']]])
+            )
+        )
 
         conn.commit()
         conn.close()

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -568,7 +568,7 @@ def main(site):
         conn = sqlite3.connect(os.path.join(webdir, 'stats.db'))
         curs = conn.cursor()
 
-        unlisted = site_tree.get_num_files(unlisted=True)
+        unlisted = site_tree.get_unlisted()
 
         curs.execute('INSERT INTO stats_history SELECT * FROM stats WHERE site=?', (site, ))
         curs.execute(

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -2,7 +2,7 @@
   "CacheLocation": "/local/dynamo/consistency/cache",
   "LogLocation": "/local/dynamo/consistency/logs",
   "WebDir": "/home/dynamo/consistency/web",
-  "MaxMissing": 1000,
+  "MaxMissing": 10000,
   "MaxOrphan": 10000,
   "Timeout": 300,
   "Retries": 3,

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -419,7 +419,7 @@ class TestInconsistentTrees(TestBase):
 class TestUnlisted(TestBase):
 
     unlisted_list = [
-        ('/store/mc/ttThings/0000/_unlisted', 0),
+        ('/store/mc/ttThings/0000/_unlisted_', 0),
         ('/store/mc/ttThings/0001/zxcvb.root', 50),
         ('/store/data/runB/_unlisted_', 0),
         ('/store/data/runB/earlyfile.root', 5),
@@ -439,6 +439,12 @@ class TestUnlisted(TestBase):
 
         orphan, _, _ = self.unlisted_tree.compare(self.tree)
         self.assertEqual(len(orphan), 0)
+
+    def test_unlisted_list(self):
+        self.assertTrue('/store/mc/ttThings/0000' in self.unlisted_tree.get_unlisted())
+        self.assertFalse('/store/mc/ttThings' in self.unlisted_tree.get_unlisted())
+        self.assertEqual(len(self.unlisted_tree.get_unlisted()),
+                         self.unlisted_tree.get_num_files(unlisted=True))
 
 
 class TestUnfilled(TestBase):

--- a/web/maketables.sql
+++ b/web/maketables.sql
@@ -1,5 +1,5 @@
-CREATE TABLE "stats" (site varchar(127) PRIMARY KEY, time float, files int, nodes int, emtpy int, cores int, missing int, m_size int, orphan int, o_size int, entered datetime, nosource int, unlisted INT DEFAULT 0, unmerged INT DEFAULT 0);
+CREATE TABLE "stats" (site varchar(127) PRIMARY KEY, time float, files int, nodes int, emtpy int, cores int, missing int, m_size int, orphan int, o_size int, entered datetime, nosource int, unlisted INT DEFAULT 0, unmerged int default 0, unlisted_bad INT DEFAULT 0);
 
-CREATE TABLE "stats_history" (site varchar(127), time float, files int, nodes int, emtpy int, cores int, missing int, m_size int, orphan int, o_size int, entered datetime, nosource int, unlisted INT DEFAULT 0, unmerged INT DEFAULT 0, PRIMARY KEY (site, entered));
+CREATE TABLE "stats_history" (site varchar(127), time float, files int, nodes int, emtpy int, cores int, missing int, m_size int, orphan int, o_size int, entered datetime, nosource int, unlisted INT DEFAULT 0, unmerged INT DEFAULT 0, unlisted_bad INT DEFAULT 0, PRIMARY KEY (site, entered));
 
 CREATE TABLE sites (site varchar(64) primary key, isgood int default 0, isrunning INT DEFAULT 0, laststarted datetime);

--- a/web/output.html
+++ b/web/output.html
@@ -75,7 +75,7 @@
            $background_nosource = ($row['nosource'] > $config['MaxMissing']) ? $bad_background : '';
            $background_orphan = ($row['orphan'] > $config['MaxOrphan']) ? $bad_background : '';
            $background_files = ($row['files'] == 0) ? $bad_background : '';
-           $background_unlisted = ($row['unlisted'] > 6) ? $bad_background : '';
+           $background_unlisted = ($row['unlisted_bad'] != 0) ? $bad_background : '';
 
            $tooltip = '';
 
@@ -104,11 +104,11 @@
            $background_time = ((strtotime($row['entered']) + 24 * 3600) > time()) ? $good_background : '';
 
            $html_row = sprintf(
-             '<td%s><a href="?history=%s">%s</a></td><td%s><a href="%s.log">%s</a>%s</td><td>%.0f</td><td%s><a href="%s_storage.json">%d</a></td><td>%d</td><td%s><a href="%s_unlisted.txt">%d</a></td><td>%d</td><td%s><a href="%s_compare_missing.txt">%d</a> [<a href="%s_missing_datasets.txt">blocks</a>]</td><td%s><a href="%s_missing_nosite.txt">%d</a></td><td>%.2f</td><td%s><a href="%s_compare_orphan.txt">%d</a></td><td>%.2f</td><td><a href="%s_unmerged.txt">%d</a></td>',
+             '<td%s><a href="?history=%s">%s</a></td><td%s><a href="%s.log">%s</a>%s</td><td>%.0f</td><td%s><a href="%s_storage.json">%d</a></td><td>%d</td><td%s><a href="%s_unlisted.txt">%d</a> [%d bad]</td><td>%d</td><td%s><a href="%s_compare_missing.txt">%d</a> [<a href="%s_missing_datasets.txt">blocks</a>]</td><td%s><a href="%s_missing_nosite.txt">%d</a></td><td>%.2f</td><td%s><a href="%s_compare_orphan.txt">%d</a></td><td>%.2f</td><td><a href="%s_unmerged.txt">%d</a></td>',
              $background_time, $row['site'], $row['entered'],
              $background_site, $row['site'], $row['site'], $tooltip, $row['time']/60.,
              $background_files, $row['site'], $row['files'], $row['nodes'], 
-             $background_unlisted, $row['site'], $row['unlisted'], $row['emtpy'],
+             $background_unlisted, $row['site'], $row['unlisted'], $row['unlisted_bad'], $row['emtpy'],
              $background_missing, $row['site'], $row['missing'], $row['site'],
              $background_nosource, $row['site'], $row['nosource'], $row['m_size']/pow(1024.,4),
              $background_orphan, $row['site'], $row['orphan'], $row['o_size']/pow(1024.,4), $row['site'], $row['unmerged']);


### PR DESCRIPTION
- Add a note in the "unlisted" column of the number of directories we're not ignoring on purpose.
- The column is color coded based on this "bad" directory number.
- Bumped up act on missing to 10,000 (was 1,000 before)
- Explicitly fill columns so that we don't crash running jobs when adding columns to the database.

Currently running on known bad sites to make sure that the unlisted column behaves appropriately. Will wait for that to end before merging.