### PR TITLE
Bug Fix

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -336,7 +336,7 @@ class DirectoryInfo(object):
         output = []
         for fil in self.files:
             # Only list old files
-            if (self.timestamp - fil['mtime']) > min_age:
+            if (self.timestamp - fil['mtime']) > min_age and fil['name'] != '_unlisted_':
                 output.append(os.path.join(path, self.name, fil['name']))
 
         for directory in self.directories:

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -446,6 +446,13 @@ class TestUnlisted(TestBase):
         self.assertEqual(len(self.unlisted_tree.get_unlisted()),
                          self.unlisted_tree.get_num_files(unlisted=True))
 
+    def test_file_list(self):
+        files = self.unlisted_tree.get_files()
+        self.assertTrue('/store/mc/ttThings/0001/zxcvb.root' in files)
+        self.assertFalse('/store/mc/ttThings/0000/_unlisted_' in files)
+        self.assertFalse(False in [f.endswith('.root') for f in files])
+        self.assertEqual(len(files), 3)
+
 
 class TestUnfilled(TestBase):
     # This is for testing the tree behavior when some of the DirectoryInfo.files is None


### PR DESCRIPTION
Was listing '_unlisted_' in file list. Only used in the unmerged cleaner implementation. Added unit test and fixed bug.