### PR TITLE
Update description so no one thinks this is for the database.

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     author='Daniel Abercrombie',
     author_email='dabercro@mit.edu',
-    description='Consistency plugin for Dynamo',
+    description='Consistency plugin for Dynamo Dynamic Data Management System',
     url='https://github.com/SmartDataProjects/dynamo-consistency',
     install_requires=['pyyaml',
                       'docutils',


### PR DESCRIPTION
`dynamo` is a database package for AWS. This package pops up in the PyPI search for `dynamo`, so I wanted to make it clear that it's different.