### PR TITLE
V26

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.5.1'
+__version__ = '2.6.0'

--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.6.0'
+__version__ = '2.6.1'

--- a/dynamo_consistency/dynamo/v1/registry.py
+++ b/dynamo_consistency/dynamo/v1/registry.py
@@ -26,7 +26,7 @@ def _get_registry():
     # Super quick bad hack to point to the right thing if inside server
     if (os.environ.get('DYNAMO_SPOOL') or os.environ['USER'] == 'dynamo') \
             and opts.CMS:
-        return MySQL(config_file='/etc/my.cnf',
+        return MySQL(config_file=opts.CNF,
                      db='dynamoregister', config_group='mysql-dynamo')
 
     # This is also really bad. Only works at MIT.
@@ -34,7 +34,7 @@ def _get_registry():
         config.config_dict().get('DBConfig', {}).get(
             'Registry',
             { # Default registry config
-                'config_file': os.path.join(os.environ['HOME'], 'my.cnf'),
+                'config_file': opts.CNF,
                 'db': 'dynamoregister',
                 'config_group': 'mysql-register-test'
             }

--- a/dynamo_consistency/main.py
+++ b/dynamo_consistency/main.py
@@ -87,7 +87,7 @@ def extras(site):
     return output
 
 
-def report_files(inv, remote, missing, orphans):
+def report_files(inv, remote, missing, orphans, prev_set):
     """
     Reports files to the history database
 
@@ -95,8 +95,10 @@ def report_files(inv, remote, missing, orphans):
     :param dynamo_consistency.datatypes.DirectoryInfo remote: The remote listing
     :param list missing: Missing files
     :param list orphans: Orphan files
+    :param set prev_set: Set of files that were missing in the previous run
     """
-    history.report_missing([(name, inv.get_file(name)) for name in missing])
+    history.report_missing([(name, inv.get_file(name)) for name in missing if
+                            prev_set is None or name in prev_set])
     history.report_orphan([(name, remote.get_file(name)) for name in orphans])
 
 
@@ -114,38 +116,6 @@ def compare_with_inventory(site):    # pylint: disable=too-many-locals
     """
 
     start = time.time()
-
-    inv_tree = inventorylister.listing(site)
-
-    # Reset the DirectoryList for the XRootDLister to run on
-    config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
-    remover = EmptyRemover(site)
-    site_tree = remotelister.listing(site, remover)
-
-    check_orphans, check_missing = make_filters(site)
-
-    work = config.vardir('work')
-
-    # Do the comparison
-    missing, m_size, orphan, o_size = datatypes.compare(
-        inv_tree, site_tree, os.path.join(work, '%s_compare' % site),
-        orphan_check=check_orphans.protected,
-        missing_check=check_missing.protected)
-
-    report_files(inv_tree, site_tree, missing, orphan)
-
-    LOG.info('Missing size: %i, Orphan size: %i', m_size, o_size)
-
-    # Determine if files should be entered into the registry
-
-    config_dict = config.config_dict()
-
-    many_missing = len(missing) > int(config_dict['MaxMissing'])
-    many_orphans = len(orphan) > int(config_dict['MaxOrphan'])
-
-    # Track files with no sources
-    no_source_files = []
-    unrecoverable = []
 
     # Filter out missing files that were not missing previously
     config_dict = config.config_dict()
@@ -170,6 +140,38 @@ def compare_with_inventory(site):    # pylint: disable=too-many-locals
                     os.path.join(config.vardir('web_bak'),
                                  prev_new_name)
                    )
+    else:
+        prev_set = None
+
+    inv_tree = inventorylister.listing(site)
+
+    # Reset the DirectoryList for the XRootDLister to run on
+    config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
+    remover = EmptyRemover(site)
+    site_tree = remotelister.listing(site, remover)
+
+    check_orphans, check_missing = make_filters(site)
+
+    work = config.vardir('work')
+
+    # Do the comparison
+    missing, m_size, orphan, o_size = datatypes.compare(
+        inv_tree, site_tree, os.path.join(work, '%s_compare' % site),
+        orphan_check=check_orphans.protected,
+        missing_check=check_missing.protected)
+
+    report_files(inv_tree, site_tree, missing, orphan, prev_set)
+
+    LOG.info('Missing size: %i, Orphan size: %i', m_size, o_size)
+
+    # Determine if files should be entered into the registry
+
+    many_missing = len(missing) > int(config_dict['MaxMissing'])
+    many_orphans = len(orphan) > int(config_dict['MaxOrphan'])
+
+    # Track files with no sources
+    no_source_files = []
+    unrecoverable = []
 
     is_debugged = summary.is_debugged(site)
 

--- a/dynamo_consistency/main.py
+++ b/dynamo_consistency/main.py
@@ -87,7 +87,7 @@ def extras(site):
     return output
 
 
-def report_files(inv, remote, missing, orphans, prev_set):
+def report_files(inv, remote, missing, orphans, prev_set=None):
     """
     Reports files to the history database
 

--- a/dynamo_consistency/parser.py
+++ b/dynamo_consistency/parser.py
@@ -80,7 +80,9 @@ def get_parser(modname='__main__',
 
     if add_all:
         backend_group.add_option('--v1-reporting', action='store_true', dest='V1_REPORTING',
-                                 help='Connect to Dynamo database directly for registry only')
+                                 help='Connect to Dynamo database directly for registry only.')
+        backend_group.add_option('--cnf', metavar='FILE', dest='CNF', default='/etc/my.cnf',
+                                 help='Point to a non-default location of a ``my.cnf`` file.')
 
     if add_all or prog in ['consistency-dump-tree'] or prog.startswith('test_'):
         backend_group.add_option('--test', action='store_true', dest='TEST',

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -150,6 +150,21 @@ class TestHistory(unittest.TestCase):
                           '/store/data/runC/0000',
                           '/store/data/runC'])
 
+    def test_prevmissing(self):
+        # Check that missing only shows up after two consecutive, if missing file there
+        site = picker.pick_site()
+
+        with open('www/%s_compare_missing.txt' % site, 'w') as missing:
+            pass
+
+        main.main(site)
+        self.assertFalse(main.registry.transfered)
+        self.assertFalse(history.missing_files(site))
+
+        main.main(site)
+        self.assertEqual(history.missing_files(main.config.SITE),
+                         ['/store/data/runB/0003/missing.root'])
+
 
 if __name__ == '__main__':
     unittest.main(argv=[a for a in sys.argv if a not in ['--info', '--debug']])


### PR DESCRIPTION
New feature:
- The config file for connecting to the database via `--v1` can be passed through the `--cnf` option

Bugfix:
- The new invalidation script was not doing the old thing of only reporting a file as invalid if it's missing in two listings in a row