### PR TITLE
Bufix

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.6.2'
+__version__ = '2.6.3'

--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.6.1'
+__version__ = '2.6.2'

--- a/dynamo_consistency/backend/listers.py
+++ b/dynamo_consistency/backend/listers.py
@@ -32,6 +32,12 @@ class Lister(object):
         config_dict = config.config_dict()
         self.log = logging.getLogger(__name__ if thread_num is None else \
                                          '%s--thread%i' % (__name__, thread_num))
+
+        for hdlr in list(self.log.handlers):
+            self.log.removeHandler(hdlr)
+        for hdlr in LOG.handlers:
+            self.log.addHandler(hdlr)
+
         self.ignore_list = config_dict.get('IgnoreDirectories', [])
         self.path_prefix = config_dict.get('PathPrefix', {}).get(site, '')
         self.tries = config_dict.get('Retries', 0) + 1

--- a/dynamo_consistency/cms/filters.py
+++ b/dynamo_consistency/cms/filters.py
@@ -5,7 +5,7 @@ This module defines any filters that are used specifically for CMS.
 import logging
 
 
-LOG = logging.getLogger(__file__)
+LOG = logging.getLogger(__name__)
 
 
 class DatasetFilter(object):


### PR DESCRIPTION
- The `listdeletable` logging now shows up in log files
- Fixed new bug that caused crash when loading trees from cached files in `main`