### PR TITLE
V27

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.7.4'
+__version__ = '2.7.5'

--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.7.3'
+__version__ = '2.7.4'

--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.7.5'
+__version__ = '2.7.6'

--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.7.2'
+__version__ = '2.7.3'

--- a/dynamo_consistency/backend/listers.py
+++ b/dynamo_consistency/backend/listers.py
@@ -109,7 +109,7 @@ class Lister(object):
         if not okay:
             okay, directories, files = self.list(path, retries + 1)
 
-        return okay, directories, files
+        return okay, sorted(set(directories)), sorted(set(files))
 
 
 def ct_timestamp(line):

--- a/dynamo_consistency/backend/redirectors.py
+++ b/dynamo_consistency/backend/redirectors.py
@@ -132,11 +132,8 @@ def get_redirector(site, banned_doors=None):
                 if domain in line:
                     redirs.append(line.strip())
 
-        if not redirs:
-            LOG.error('Could not get redirector for %s with domain %s', site, domain)
-            return '', []
-
-        redirector = redirs[0]
+        if redirs:
+            redirector = redirs[0]
     else:
         redirs.append(redirector)
 
@@ -149,6 +146,10 @@ def get_redirector(site, banned_doors=None):
     with open(list_name, 'r') as list_file:
         local_list = [line.strip() for line in list_file \
                           if line.strip() not in banned_doors and domain in line]
+
+    if not os.path.getsize(list_name):
+        LOG.error('Redirector list %s is empty, removing', list_name)
+        os.remove(list_name)
 
     LOG.info('From %s, got doors %s', redirector, local_list)
     LOG.info('Full list from global redirectors: %s', redirs)

--- a/scripts/get_unmerged_size.py
+++ b/scripts/get_unmerged_size.py
@@ -7,7 +7,7 @@ from dynamo_consistency.datatypes import get_info
 
 site = sys.argv[1]
 # Should actually get these from config JSON file
-cache_dir = '/local/dynamo/consistency/cache'
+cache_dir = '/slocal/dynamo/consistency/cache'
 web_dir = '/home/dynamo/consistency/web'
 
 # Load in files first

--- a/test/test_flags.py
+++ b/test/test_flags.py
@@ -60,7 +60,7 @@ class TestSize(unittest.TestCase):
         self.assertEqual(datatypes.compare(invent, remote)[1], 400)
 
 
-class TestEmtpyDirs(unittest.TestCase):
+class TestEmptyDirs(unittest.TestCase):
     # We had a bug where non-existant directories in the inventory was comparable
     # since a subset of subdirectories were comparable.
     # However, some of these subdirectories were also new, but deleted anyway.

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -144,7 +144,7 @@ class TestHistory(unittest.TestCase):
                          ['/store/data/runB/0003/missing.root'])
         self.assertEqual(history.orphan_files(main.config.SITE),
                          ['/store/data/runB/0001/orphan.root'])
-        self.assertEqual(history.emtpy_directories(main.config.SITE),
+        self.assertEqual(history.empty_directories(main.config.SITE),
                          ['/store/data/runC/0000/emtpy/dir',
                           '/store/data/runC/0000/emtpy',
                           '/store/data/runC/0000',
@@ -164,6 +164,37 @@ class TestHistory(unittest.TestCase):
         main.main(site)
         self.assertEqual(history.missing_files(main.config.SITE),
                          ['/store/data/runB/0003/missing.root'])
+
+    def test_multiplemissing(self):
+        site = picker.pick_site()
+        history.start_run()
+        history.report_empty([('/store/test/empty/dir', 100)])
+        history.report_empty([('/store/test/empty/dir', 100)])
+        history.finish_run()
+
+        self.assertEqual(history.empty_directories(site),
+                         ['/store/test/empty/dir'])
+
+
+        history.start_run()
+        history.report_empty([('/store/test/empty/dir2', 100),
+                              ('/store/test/empty/dir2', 100)])
+        history.finish_run()
+
+        self.assertEqual(history.empty_directories(site),
+                         ['/store/test/empty/dir2'])
+
+    def test_act(self):
+        site = picker.pick_site()
+        history.start_run()
+        history.report_empty([('/store/test/empty/dir', 100)])
+        history.finish_run()
+        
+        self.assertEqual(history.empty_directories(site),
+                         ['/store/test/empty/dir'])
+        self.assertEqual(history.empty_directories(site, True),
+                         ['/store/test/empty/dir'])
+        self.assertFalse(history.empty_directories(site))
 
 
 if __name__ == '__main__':

--- a/test/test_noorphans.py
+++ b/test/test_noorphans.py
@@ -29,14 +29,14 @@ class TestNoOrphanMain(unittest.TestCase):
         self.assertEqual(history.missing_files(main.config.SITE),
                          ['/store/data/runB/0003/missing.root'])
         self.assertFalse(history.orphan_files(main.config.SITE))
-        self.assertEqual(history.emtpy_directories(main.config.SITE),
+        self.assertEqual(history.empty_directories(main.config.SITE),
                          ['/store/data/runC/0000/emtpy/dir',
                           '/store/data/runC/0000/emtpy',
                           '/store/data/runC/0000',
                           '/store/data/runC'])
 
         self.assertEqual(sorted(main.registry.deleted, reverse=True),
-                         history.emtpy_directories(main.config.SITE))
+                         history.empty_directories(main.config.SITE))
 
     def test_flag(self):
         main.opts.NOORPHAN = True

--- a/test/test_redirector.py
+++ b/test/test_redirector.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+
+import os
+import shutil
+import unittest
+
+import base
+
+from dynamo_consistency import config
+from dynamo_consistency.backend import redirectors
+
+config.config_dict()
+config.CONFIG['GlobalRedirectors'] = []
+redirectors.get_domain = lambda _: 'example.com'
+
+class TestRedirectors(unittest.TestCase):
+    def setUp(self):
+        if os.path.exists('var'):
+            shutil.rmtree('var')
+
+        self.file_name = os.path.join(config.vardir('redirectors'), 'TEST_SITE_redirector_list.txt')
+
+    def test_empty(self):
+        redirector, doors = redirectors.get_redirector('TEST_SITE')
+        self.assertFalse(redirector)
+        self.assertFalse(doors)
+
+        self.assertFalse(os.path.exists(self.file_name))
+
+    def test_list(self):
+        with open(self.file_name, 'w') as redlist:
+            redlist.write('test.example.com\n')
+
+        redirector, doors = redirectors.get_redirector('TEST_SITE')
+        self.assertFalse(redirector)
+        self.assertEqual(doors, ['test.example.com'])
+
+
+if __name__ == '__main__':
+    unittest.main(argv=base.ARGS)

--- a/test/test_summarylock.py
+++ b/test/test_summarylock.py
@@ -1,0 +1,42 @@
+#! /usr/bin/env python
+
+import os
+import shutil
+import unittest
+import threading
+from time import sleep
+
+from dynamo_consistency import summary
+from dynamo_consistency import picker
+from dynamo_consistency.summary import _connect
+
+class TestSummary(unittest.TestCase):
+    def setUp(self):
+        for dirname in ['www', 'var']:
+            if os.path.exists(dirname):
+                shutil.rmtree(dirname)
+        summary.unlock_site(picker.pick_site())
+
+    def test_site(self):
+        conn = _connect()
+
+        self.assertEqual(list(conn.execute("SELECT site, isgood FROM sites WHERE site = 'TEST_SITE'")),
+                         [('TEST_SITE', 0)])
+
+        updater = threading.Thread(target=lambda: os.system('set-status TEST_SITE act'))
+        updater.start()
+
+        sleep(3)
+        self.assertEqual(list(conn.execute("SELECT site, isgood FROM sites WHERE site = 'TEST_SITE'")),
+                         [('TEST_SITE', 0)])
+        conn.close()
+        updater.join()
+
+        conn = _connect()
+        self.assertEqual(list(conn.execute("SELECT site, isgood FROM sites WHERE site = 'TEST_SITE'")),
+                         [('TEST_SITE', 1)])
+        conn.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Bugfixes:
- Explicitly lock sqlite3 databases (both history and summary) before accessing so that they don't crash
- Allow duplicate attempts to report empty directories to history (just reports error for now)
- Used cached redirector list so that incomplete global redirectors don't stop sites from running
- Change a bunch of `emtpy` to `empty` (but not the one in the summary table)