### PR TITLE
Recover Missing RAW Files

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.7.6'
+__version__ = '2.7.7'

--- a/dynamo_consistency/backend/listers.py
+++ b/dynamo_consistency/backend/listers.py
@@ -38,7 +38,6 @@ class Lister(object):
         for hdlr in LOG.handlers:
             self.log.addHandler(hdlr)
 
-        self.ignore_list = config_dict.get('IgnoreDirectories', [])
         self.path_prefix = config_dict.get('PathPrefix', {}).get(site, '')
         self.tries = config_dict.get('Retries', 0) + 1
 
@@ -74,11 +73,6 @@ class Lister(object):
                   The modification times are in seconds from epoch and the file size is in bytes.
         :rtype: bool, list, list
         """
-        # Skip over paths that include part of the list of ignored directories
-        for pattern in self.ignore_list:
-            if pattern in path:
-                self.log.warning('Ignoring %s because of ignored pattern %s', path, pattern)
-                return False, [], []
 
         if retries >= self.tries:
             self.log.error('Giving up on %s due to too many retries', path)

--- a/dynamo_consistency/cms/unmerged.py
+++ b/dynamo_consistency/cms/unmerged.py
@@ -15,6 +15,7 @@ from .. import history
 from .. import remotelister
 from .. import summary
 from ..backend import registry
+from ..backend import listers
 from ..emptyremover import EmptyRemover
 
 
@@ -103,7 +104,7 @@ def clean_unmerged(site):
     :rtype: int, int
     """
 
-    ## First, we do a bunch of hacky configuration changes for /store/unmerged
+    # First, we do a bunch of hacky configuration changes for /store/unmerged
     listdeletable.set_config(config.LOCATION, 'ListDeletable')
 
     # Set the directory list to unmerged only
@@ -152,6 +153,9 @@ def clean_unmerged(site):
         LOG.debug('%s is NOT protected', path)
         return False
 
+
+    # Turn on the filtering of ignored directories
+    listers.FILTER_IGNORED = True
 
     # And do a listing of unmerged
     site_tree = remotelister.listing(    # pylint: disable=unexpected-keyword-arg

--- a/dynamo_consistency/consistency_config.json
+++ b/dynamo_consistency/consistency_config.json
@@ -19,7 +19,9 @@
     "data",
     "hidata"
   ],
-  "IgnoreDirectories": [],
+  "IgnoreDirectories": [
+    "/RAW"
+  ],
   "GlobalRedirectors": [
     "cms-xrd-global.cern.ch"
   ],

--- a/dynamo_consistency/emptyremover.py
+++ b/dynamo_consistency/emptyremover.py
@@ -33,6 +33,8 @@ class EmptyRemover(object):
         self.check = check or (lambda _: False)
         self.removed = 0
         self.root = config.config_dict()['RootPath']
+        # This is a set of directories that have a filtered directory inside
+        self.not_empty = set()
 
     def fullname(self, name):
         """
@@ -59,11 +61,10 @@ class EmptyRemover(object):
         """
         tree.setup_hash()
         empties = [empty for empty in tree.empty_nodes_list()
-                   if not self.check(self.fullname(empty))]
+                   if not self.check(self.fullname(empty)) and
+                   empty not in self.not_empty]
 
         LOG.debug('Sees %s', empties)
-
-        not_empty = []
 
         strip_len = len(tree.name) + 1
         empties_info = []
@@ -79,7 +80,7 @@ class EmptyRemover(object):
 
             except datatypes.NotEmpty as msg:
                 LOG.warning('While removing %s: %s', path, msg)
-                not_empty.append(path)
+                self.not_empty.add(path)
 
         full_empties = [info[0] for info in empties_info]
 

--- a/dynamo_consistency/main.py
+++ b/dynamo_consistency/main.py
@@ -298,5 +298,6 @@ def main(site):
             **report)
 
         summary.move_local_files(site)
+        summary.update_config()
 
     history.finish_run()

--- a/dynamo_consistency/main.py
+++ b/dynamo_consistency/main.py
@@ -192,19 +192,8 @@ def compare_with_inventory(site):    # pylint: disable=too-many-locals
 
     is_debugged = summary.is_debugged(site)
 
-    # Only get the empty nodes that are not in the inventory tree
-    empties = [empty_node for empty_node in site_tree.empty_nodes_list() \
-                   if not inv_tree.get_node('/'.join(empty_node.split('/')[2:]),
-                                            make_new=False)]
-
     if is_debugged and not many_missing and not many_orphans:
-        registry.delete(site, orphan + empties)
-        strip_len = len(site_tree.name) + 1
-        history.report_empty(
-            [(empty,
-              site_tree.get_node(empty[strip_len:], make_new=False).mtime)
-             for empty in empties])
-
+        registry.delete(site, orphan)
         no_source_files, unrecoverable = registry.transfer(
             site, [f for f in missing if not prev_set or f in prev_set])
 
@@ -255,7 +244,7 @@ def compare_with_inventory(site):    # pylint: disable=too-many-locals
         return start, {
             'numfiles': site_tree.get_num_files(),
             'numnodes': remover.get_removed_count() + site_tree.count_nodes(),
-            'numempty': remover.get_removed_count() + len(empties),
+            'numempty': remover.get_removed_count(),
             'nummissing': len(missing),
             'missingsize': m_size,
             'numorphan': len(orphan),

--- a/test/redefine_lister.py
+++ b/test/redefine_lister.py
@@ -1,0 +1,14 @@
+from dynamo_consistency import remotelister
+from dynamo_consistency.backend import test
+from dynamo_consistency.backend import listers
+
+# Do the listing through the listers.Lister interface
+# so that the IgnoreDirectories list of the old version is used
+class TestLister(listers.Lister):
+    def __init__(self):
+        super(TestLister, self).__init__(0, 'TEST')
+
+    def ls_directory(self, path):
+        return test._ls(path)
+
+remotelister.get_listers = lambda _: (TestLister, [(), ()])

--- a/test/test_protected.py
+++ b/test/test_protected.py
@@ -2,15 +2,13 @@
 
 import unittest
 
-import base
-
 from dynamo_consistency import picker
 from dynamo_consistency import main
 from dynamo_consistency import history
-from dynamo_consistency.backend import listers
 from dynamo_consistency.backend import test
-from dynamo_consistency import remotelister
 
+import base
+import redefine_lister
 
 test._FILES = sorted([
     ('/store/mc/ttThings/0000/qwert.root', 20),
@@ -25,19 +23,6 @@ test._INV = sorted([
     ('/store/data/runC/RAW/0000/reg.root', 100),
     ('/store/data/runC/RAW/0000/missing.root', 100)
     ])
-
-
-# Do the listing through the listers.Lister interface
-# so that the IgnoreDirectories list of the old version is used
-class TestLister(listers.Lister):
-    def __init__(self):
-        super(TestLister, self).__init__(0, 'TEST')
-
-    def ls_directory(self, path):
-        return test._ls(path)
-
-
-remotelister.get_listers = lambda _: (TestLister, [(), ()])
 
 
 class TestProtected(base.TestBase):

--- a/test/test_protected.py
+++ b/test/test_protected.py
@@ -1,0 +1,65 @@
+#! /usr/bin/env python
+
+import unittest
+
+import base
+
+from dynamo_consistency import picker
+from dynamo_consistency import main
+from dynamo_consistency import history
+from dynamo_consistency.backend import listers
+from dynamo_consistency.backend import test
+from dynamo_consistency import remotelister
+
+
+test._FILES = sorted([
+    ('/store/mc/ttThings/0000/qwert.root', 20),
+    ('/store/mc/ttThings/0000/orphan.root', 20),
+    ('/store/data/runC/RAW/0000/reg.root', 100),
+    ('/store/data/runC/RAW/0000/orphan.root', 100),
+    ('/store/data/runC/RAW/0000/empty', ),
+    ])
+
+test._INV = sorted([
+    ('/store/mc/ttThings/0000/qwert.root', 20),
+    ('/store/data/runC/RAW/0000/reg.root', 100),
+    ('/store/data/runC/RAW/0000/missing.root', 100)
+    ])
+
+
+# Do the listing through the listers.Lister interface
+# so that the IgnoreDirectories list of the old version is used
+class TestLister(listers.Lister):
+    def __init__(self):
+        super(TestLister, self).__init__(0, 'TEST')
+
+    def ls_directory(self, path):
+        return test._ls(path)
+
+
+remotelister.get_listers = lambda _: (TestLister, [(), ()])
+
+
+class TestProtected(base.TestBase):
+
+    def do_more_setup(self):
+        # Run the main program
+        main.main(picker.pick_site())
+
+    def test_removed(self):
+        # Note that there's no RAW file here to delete
+        self.assertEqual(history.orphan_files(main.config.SITE),
+                         ['/store/mc/ttThings/0000/orphan.root'])
+
+    def test_missing(self):
+        # We do want to recover one of the files though
+        self.assertEqual(history.missing_files(main.config.SITE),
+                         ['/store/data/runC/RAW/0000/missing.root'])
+
+    def test_empty(self):
+        # Don't delete directories in the protected folders
+        self.assertFalse(history.empty_directories(main.config.SITE))
+
+
+if __name__ == '__main__':
+    unittest.main(argv=base.ARGS)

--- a/test/test_unmerged.py
+++ b/test/test_unmerged.py
@@ -12,6 +12,7 @@ from dynamo_consistency.backend.test import TMP_DIR
 from dynamo_consistency.backend import registry
 
 import base
+import redefine_lister
 
 
 unmerged.listdeletable.get_protected = lambda: [
@@ -24,10 +25,12 @@ class TestUnmerged(base.TestListing):
     file_list = [
         ('/store/unmerged/protected/000/qwert.root', 20),
         ('/store/unmerged/notprot/000/qwert.root', 20),
-        ('/store/unmerged/logs/000/logfile.tar.gz', 20)
+        ('/store/unmerged/logs/000/logfile.tar.gz', 20),
+        ('/store/unmerged/ignore/RAW/000/file.root', 20)
         ]
 
     dir_list = [
+        '/store/unmerged/ignore/RAW/empty',
         '/store/unmerged/protected/empty',
         '/store/unmerged/protected2',
         ]


### PR DESCRIPTION
Filtered directories were not being listed at all in the regular check. This meant it was impossible to recover RAW data files as well.
- All directories now listed during consistency portion, but filters applied to orphan file list and empty directory removal
- Filtered directories still not listed at all during /store/unmerged cleaning
- New unit tests to ensure that this works as intended. Test instance also looks good running over T2_US_MIT now
