### PR TITLE
Lock select

### DIFF
--- a/bin/dynamo-consistency
+++ b/bin/dynamo-consistency
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         exit(0)
 
     # Get the site to run on
-    site = picker.pick_site(opts.SITE_PATTERN)
+    site = picker.pick_site(opts.SITE_PATTERN, opts.LOCK_NAME)
 
     # Check if needs lock (like for gfal)
     needed_lock = lock.which(site)

--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.9.7'
+__version__ = '2.10.0'

--- a/dynamo_consistency/parser.py
+++ b/dynamo_consistency/parser.py
@@ -39,17 +39,25 @@ def get_parser(modname='__main__', # pylint: disable=too-complex
 
     parser.add_option('--config', metavar='FILE', dest='CONFIG',
                       help='Sets the location of the configuration file to read.')
+
+    selection_group = optparse.OptionGroup(parser, 'Selection Options')
+
     if add_all or prog in ['consistency-invalidate', 'consistency-dump-tree']:
-        parser.add_option('--site', metavar='PATTERN', dest='SITE_PATTERN',
-                          help='Sets the pattern used to select a site to run on next.')
+        selection_group.add_option('--site', metavar='PATTERN', dest='SITE_PATTERN',
+                                   help='Sets the pattern used to select a site to run on next.')
+
+    if add_all:
+        selection_group.add_option('--lock', metavar='NAME', dest='LOCK_NAME',
+                                   help='Sets the lock name that should be used for this run.',
+                                   default=None)
 
     if prog == 'consistency-dump-tree':
-        parser.add_option('--remote', action='store_true', dest='REMOTE',
-                          help='Dump the remote site listing instead of the inventory')
+        selection_group.add_option('--remote', action='store_true', dest='REMOTE',
+                                   help='Dump the remote site listing instead of the inventory')
 
     if add_all or prog == 'consistency-dump-tree':
-        parser.add_option('--date-string', metavar='YYYYMMDD', dest='DATESTRING',
-                          help='Set the datestring to pull for RAL-Reader listers')
+        selection_group.add_option('--date-string', metavar='YYYYMMDD', dest='DATESTRING',
+                                   help='Set the datestring to pull for RAL-Reader listers')
 
     log_group = optparse.OptionGroup(parser, 'Logging Options')
 

--- a/dynamo_consistency/picker.py
+++ b/dynamo_consistency/picker.py
@@ -18,12 +18,14 @@ from .backend import check_site
 LOG = logging.getLogger(__name__)
 
 
-def pick_site(pattern=None):
+def pick_site(pattern=None, lockname=None):
     """
     This function also does the task of syncronizing the summary database with
     the inventory's list of sites that match the pattern.
 
     :param str pattern: A regex that needs to be contained in the site name
+    :param str lockname: Name of the lock file that the site should use.
+                         Needs to be `''` for guaranteed no lock.
     :returns: The name of a site that is ready and hasn't run in the longest time
     :rtype: str
     :raises NoMatchingSite: If no site matches or is ready
@@ -64,7 +66,8 @@ def pick_site(pattern=None):
             """):
         LOG.debug('Considering %s (run status %s)', site, isrunning)
         if site in sites and \
-                (isrunning == 0 or isrunning == -1):
+                (isrunning == 0 or isrunning == -1) and \
+                (lockname is None or (lock.which(site) == lockname)):
             if check_site(site):
                 output = site
                 break

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
                       'docutils',
                       'MySQL-python',
                       'psutil',
-                      'cmstoolbox>=0.11.1'],
+                      'cmstoolbox>=0.14.1'],
     scripts=[s for s in glob.iglob('bin/*') if not s.endswith('~')],
     python_requires='>=2.6, <3',
     package_data={   # Test data for document building

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ import setuptools
 import dynamo_consistency
 
 with open('README.rst', 'r') as fh:
-    long_description = fh.read()
+    long_description = ''.join([
+        line for line in fh if
+        ':ref:' not in line
+    ])
 
 setuptools.setup(
     name='dynamo-consistency',

--- a/test/locktest.json
+++ b/test/locktest.json
@@ -1,0 +1,53 @@
+{
+  "Timeout": 60,
+  "Retries": 1,
+  "InventoryAge": 5e-05,
+  "NumThreads": 1,
+  "GFALThreads": 32,
+  "ListAge": 5e-05,
+  "IgnoreAge": 1,
+  "RedirectorAge": 1,
+  "VarLocation": "var",
+  "Redirectors": {
+    "T3_US_MIT": "t3serv006.mit.edu"
+  },
+  "PathPrefix": {},
+  "AccessMethod": {
+    "GFAL_SITE": "SRM"
+  },
+  "RootPath": "/store",
+  "DirectoryList": [
+    "mc",
+    "data",
+    "hidata"
+  ],
+  "IgnoreDirectories": [
+    "/RAW"
+  ],
+  "GlobalRedirectors": [
+    "cms-xrd-global.cern.ch"
+  ],
+  "SaveCache": 0,
+  "UseLoadBalancer": [],
+  "WebDir": "www",
+  "MaxMissing": 100,
+  "MaxOrphan": 1000,
+  "Unmerged": [
+    "T2_US_MIT",
+    "TEST_SITE"
+  ],
+  "UnmergedLogsAge": 60,
+  "AdditionalLogDeletions": {
+    "TEST_SITE": ["logs/prod/recent"]
+  },
+  "FreeMem": 0,
+  "ListDeletable": {
+    "LFN_TO_CLEAN": "/store/unmerged",
+    "UNMERGED_DIR_LOCATION": "/store/unmerged",
+    "WHICH_LIST": "files",
+    "DELETION_FILE": "_unmerged.txt",
+    "DIRS_TO_AVOID": ["logs", "tier0_harvest", "express", "data"],
+    "MIN_AGE": 2419200
+  },
+  "DeleteOrphans": 1
+}

--- a/test/test_exelock.sh
+++ b/test/test_exelock.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+for directory in "www" "var"
+do
+
+    test ! -d $directory || rm -r $directory
+
+done
+
+dynamo-consistency --test --lock '' || exit 1
+dynamo-consistency --test --lock 'fake' && exit 2
+
+exit 0

--- a/test/test_lockselect.py
+++ b/test/test_lockselect.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+
+import os
+import sys
+import unittest
+
+from dynamo_consistency import config
+
+config.LOCATION = 'locktest.json'
+
+from dynamo_consistency import picker
+
+picker.siteinfo.site_list = lambda: ['TEST_SITE', 'BAD_SITE', 'GFAL_SITE']
+picker.siteinfo.ready_list = lambda: ['TEST_SITE', 'GFAL_SITE']
+picker.check_site = lambda site: site in picker.siteinfo.ready_list()
+
+
+import base
+
+
+class TestLockSelection(unittest.TestCase):
+    def setUp(self):
+        os.remove(os.path.join(os.path.dirname(__file__), 'www', 'stats.db'))
+
+    def test_normal(self):
+        self.assertEqual(picker.pick_site('TEST'), 'TEST_SITE')
+        self.assertEqual(picker.pick_site('GFAL'), 'GFAL_SITE')
+        self.assertRaises(picker.NoMatchingSite, picker.pick_site, 'BAD')
+
+    def test_gfal(self):
+        self.assertRaises(picker.NoMatchingSite, picker.pick_site, 'TEST', 'gfal')
+        self.assertEqual(picker.pick_site('GFAL', 'gfal'), 'GFAL_SITE')
+
+    def test_nolock(self):
+        self.assertEqual(picker.pick_site('TEST', ''), 'TEST_SITE')
+        self.assertRaises(picker.NoMatchingSite, picker.pick_site, 'GFAL', '')
+
+    def test_getgfal(self):
+        self.assertEqual(picker.pick_site(lockname='gfal'), 'GFAL_SITE')
+
+    def test_getnolock(self):
+        self.assertEqual(picker.pick_site(lockname=''), 'TEST_SITE')
+
+
+if __name__ == '__main__':
+    unittest.main(argv=base.ARGS)


### PR DESCRIPTION
New feature allowing gfal sites to be run in a separate dynamo schedule than other sites.

This is becoming a problem when all the gfal sites are queued at the same time. Since no more than one can run at a time, nothing is running for a while. The jobs also fail because they spend most of dynamo's time limits in the queue.
