### PR TITLE
Treename bugfix

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.11.0'
+__version__ = '2.11.1'

--- a/dynamo_consistency/datatypes.py
+++ b/dynamo_consistency/datatypes.py
@@ -559,10 +559,13 @@ class DirectoryInfo(object):
         :raises BadPath: if the file_name does not start with ``self.name``
         """
 
+        LOG.debug('Getting file info for: %s', file_name)
+
         if not file_name.startswith(self.name):
             raise BadPath('self.name is %s, file_name is %s' % (self.name, file_name))
 
-        exploded_name = file_name[len(self.name) + 1:].split('/')
+        exploded_name = file_name[len(self.name) +
+                                  (1 if self.name[-1] != '/' else 0):].split('/')
         desired_name = exploded_name[-1]
         node = self.get_node('/'.join(exploded_name[:-1]))
 

--- a/test/requirements26.txt
+++ b/test/requirements26.txt
@@ -1,4 +1,4 @@
 astroid<1.3
 pylint<1.4
-docutils<1.6
+docutils<0.16
 setuptools==36.8.0

--- a/test/requirements26.txt
+++ b/test/requirements26.txt
@@ -1,3 +1,4 @@
 astroid<1.3
 pylint<1.4
+docutils<1.6
 setuptools==36.8.0

--- a/test/test_treename.py
+++ b/test/test_treename.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python
+
+import unittest
+
+from base import ARGS
+
+from dynamo_consistency import datatypes
+
+class TestTreeName(unittest.TestCase):
+    def test_getfile(self):
+        filelist = ['/test/dir/file.txt']
+        for name in ['/test', '/']:
+
+            tree = datatypes.DirectoryInfo(name)
+            tree.add_file_list([(f, 10, 0) for f in filelist])
+
+            self.assertEqual(tree.name, name)
+            self.assertEqual(tree.get_files(), filelist)
+            self.assertEqual(tree.get_file(filelist[0])['size'], 10)
+
+if __name__ == '__main__':
+    unittest.main(argv=ARGS)


### PR DESCRIPTION
Fixes bug getting file information when the `DirectoryInfo.name = '/'`, which happens more than never.