### PR TITLE
Alternate unmerged root

### DIFF
--- a/dynamo_consistency/_version.py
+++ b/dynamo_consistency/_version.py
@@ -2,4 +2,4 @@
 Hold the version here
 """
 
-__version__ = '2.11.0'
+__version__ = '2.12.0'

--- a/dynamo_consistency/backend/__init__.py
+++ b/dynamo_consistency/backend/__init__.py
@@ -1,3 +1,5 @@
+#pylint: disable=undefined-variable
+
 """
 The "backend" handles all of the connections to dynamo objects and databases
 as well as connections for performing listings of remote or local filesystems.
@@ -136,6 +138,14 @@ _THIS = sys.modules[__name__]
 
 for thing in _PROVIDE:
     setattr(_THIS, thing, getattr(mod, thing))
+
+if opts.NO_INV:
+    siteinfo.site_list = lambda: [opts.SITE_PATTERN]
+    siteinfo.ready_sites = lambda: set([opts.SITE_PATTERN])
+    inventory.protected_datasets = lambda _: set()
+    inventory.list_files = lambda _: []
+    registry.transfer = lambda x, y: ([], [])
+    inventory.filelist_to_blocklist = lambda x, y: []
 
 __doc__ += '\n'.join( # pylint: disable=redefined-builtin
     ["""

--- a/dynamo_consistency/cms/unmerged.py
+++ b/dynamo_consistency/cms/unmerged.py
@@ -109,7 +109,7 @@ def clean_unmerged(site):  # pylint: disable=too-complex
     listdeletable.set_config(config.LOCATION, 'ListDeletable')
 
     # Set the directory list to unmerged only
-    config.DIRECTORYLIST = ['unmerged/PhaseIIMTDTDRAutumn18MiniAOD']
+    config.DIRECTORYLIST = ['unmerged']
     logsdirs = ['unmerged/logs']
     if opts.MORELOGS:
         morelogs = config.CONFIG.get('AdditionalLogDeletions', {}).get(site, [])
@@ -180,6 +180,7 @@ def clean_unmerged(site):  # pylint: disable=too-complex
     new_root = config.CONFIG['ListDeletable'].get('AlternateRoot', {}).get(site)
     if new_root:
         config.CONFIG['RootPath'] = new_root
+        listdeletable.config.UNMERGED_DIR_LOCATION = os.path.join(new_root, 'unmerged')
 
     # And do a listing of unmerged
     site_tree = remotelister.listing(    # pylint: disable=unexpected-keyword-arg
@@ -205,7 +206,7 @@ def clean_unmerged(site):  # pylint: disable=too-complex
 
     rootpath = config.CONFIG['RootPath']
     listdeletable.get_unmerged_files = lambda: [
-        os.path.join('/store', fil) for fil in
+        os.path.join(rootpath, fil) for fil in
         site_tree.get_node('unmerged').get_files(listdeletable.config.MIN_AGE)
     ]
 

--- a/dynamo_consistency/cms/unmerged.py
+++ b/dynamo_consistency/cms/unmerged.py
@@ -109,7 +109,7 @@ def clean_unmerged(site):  # pylint: disable=too-complex
     listdeletable.set_config(config.LOCATION, 'ListDeletable')
 
     # Set the directory list to unmerged only
-    config.DIRECTORYLIST = ['unmerged']
+    config.DIRECTORYLIST = ['unmerged/PhaseIIMTDTDRAutumn18MiniAOD']
     logsdirs = ['unmerged/logs']
     if opts.MORELOGS:
         morelogs = config.CONFIG.get('AdditionalLogDeletions', {}).get(site, [])
@@ -176,6 +176,11 @@ def clean_unmerged(site):  # pylint: disable=too-complex
     # Turn on the filtering of ignored directories
     listers.FILTER_IGNORED = True
 
+    # Overwrite the RootPath, if needed
+    new_root = config.CONFIG['ListDeletable'].get('AlternateRoot', {}).get(site)
+    if new_root:
+        config.CONFIG['RootPath'] = new_root
+
     # And do a listing of unmerged
     site_tree = remotelister.listing(    # pylint: disable=unexpected-keyword-arg
         site, cache='unmerged',          # cache keyword comes from cache decorator
@@ -200,7 +205,7 @@ def clean_unmerged(site):  # pylint: disable=too-complex
 
     rootpath = config.CONFIG['RootPath']
     listdeletable.get_unmerged_files = lambda: [
-        os.path.join(rootpath, fil) for fil in
+        os.path.join('/store', fil) for fil in
         site_tree.get_node('unmerged').get_files(listdeletable.config.MIN_AGE)
     ]
 

--- a/dynamo_consistency/cms/unmerged.py
+++ b/dynamo_consistency/cms/unmerged.py
@@ -89,7 +89,7 @@ def report_contents(timestamp, site, files):
     shutil.move(db_name, webdir)
 
 
-def clean_unmerged(site):  # pylint: disable=too-complex
+def clean_unmerged(site):  # pylint: disable=too-complex, too-many-branches
     """
     Lists the /store/unmerged area of a site, and then uses
     :py:mod:`cmstoolbox.unmergedcleaner.listdeletable`

--- a/dynamo_consistency/datatypes.py
+++ b/dynamo_consistency/datatypes.py
@@ -559,10 +559,13 @@ class DirectoryInfo(object):
         :raises BadPath: if the file_name does not start with ``self.name``
         """
 
+        LOG.debug('Getting file info for: %s', file_name)
+
         if not file_name.startswith(self.name):
             raise BadPath('self.name is %s, file_name is %s' % (self.name, file_name))
 
-        exploded_name = file_name[len(self.name) + 1:].split('/')
+        exploded_name = file_name[len(self.name) +
+                                  (1 if self.name[-1] != '/' else 0):].split('/')
         desired_name = exploded_name[-1]
         node = self.get_node('/'.join(exploded_name[:-1]))
 

--- a/dynamo_consistency/parser.py
+++ b/dynamo_consistency/parser.py
@@ -86,6 +86,8 @@ def get_parser(modname='__main__', # pylint: disable=too-complex
                                  help='Disables the SAM readiness check.')
         backend_group.add_option('--more-logs', action='store_true', dest='MORELOGS',
                                  help='Clean any "AdditionalLogDeletions" directories.')
+        backend_group.add_option('--no-inventory', action='store_true', dest='NO_INV',
+                                 help='Do not connect the inventory. Used to test unmerged')
 
     if add_all or prog in ['consistency-dump-tree']:
         backend_group.add_option('--unmerged', action='store_true', dest='UNMERGED',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
                       'docutils',
                       'MySQL-python',
                       'psutil',
-                      'cmstoolbox>=0.14.2'],
+                      'cmstoolbox>=0.14.4'],
     scripts=[s for s in glob.iglob('bin/*') if not s.endswith('~')],
     python_requires='>=2.6, <3',
     package_data={   # Test data for document building

--- a/test/test_pick.py
+++ b/test/test_pick.py
@@ -46,6 +46,21 @@ class TestPickRegex(unittest.TestCase):
         self.assertRaises(picker.NoMatchingSite, picker.pick_site)
 
 
+    def test_no_ral_or_fnal(self):
+        # Set all T2s to running
+        self.loop('^T2_')
+
+        # Set all other T1s
+        self.loop('(?<!(K_RAL|_FNAL))_Disk')
+
+        # Pick RAL
+        self.assertEqual(picker.pick_site('UK_RAL'), 'T1_UK_RAL_Disk')
+
+        # Only FNAL is left
+        self.assertEqual(picker.pick_site(), 'T1_US_FNAL_Disk')
+        self.assertRaises(picker.NoMatchingSite, picker.pick_site)
+
+
 
 if __name__ == '__main__':
     unittest.main(argv=base.ARGS)


### PR DESCRIPTION
Allows `/store/unmerged` to be in a different location (like just `/unmerged`)